### PR TITLE
[BUGFIX-5] Improve file media type extraction from directory name

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,12 +170,12 @@ function getFilesFromDir(dir) {
 
 /**
  * Retrieves the folder name from a string representing a directory and file
- * @param {String} dir A string representing a directory in the format "./directory/file"
+ * @param {String} str - A string representing a path directory alike in the format "./directory/file"
  * @returns {String} The extracted directory name
  */
-function getMediaFromDirectory(dir) {
-  const slash = dir.lastIndexOf("/");
-  let mediaType = dir.slice(2, slash);
+function getMediaTypeFromDirectoryPath(str) {
+  const slash = str.lastIndexOf("/");
+  let mediaType = str.slice(2, slash);
   return mediaType;
 }
 
@@ -266,7 +266,7 @@ function parseDirectory(directory) {
   let dirChildren = []; // this will hold the output each markdown doc
   let dirErrors = []; //contains error for a given directory
 
-  let mediaType = getMediaFromDirectory(directory);
+  let mediaType = getMediaTypeFromDirectoryPath(directory);
   const filenames = getFilesFromDir(path.resolve(directory));
   filenames.forEach((filename) => {
     const doc = fs.readFileSync(filename);

--- a/index.js
+++ b/index.js
@@ -174,9 +174,17 @@ function getFilesFromDir(dir) {
  * @returns {String} The extracted directory name
  */
 function getMediaTypeFromDirectoryPath(str) {
-  const slash = str.lastIndexOf("/");
-  let mediaType = str.slice(2, slash);
-  return mediaType;
+  str = path.resolve(str); // sanatize and expand (OS independent)
+  let type;
+  if (fs.lstatSync(str).isDirectory()) {
+    // if path is itself a directory, use it name as result
+    type = path.basename(str);
+  } else {
+    // if not... parent/previous slug is always a directory; extract this part
+    // path.sep: Windows -> "\", Unix -> "/"
+    type = str.split(path.sep).slice(-2, -1).join(path.sep);
+  }
+  return type;
 }
 
 /**


### PR DESCRIPTION
### Description

* Before...

| Linux (github actions) | Windows (local) |
|:---:|:---:|
| ![image](https://user-images.githubusercontent.com/3125580/189906112-bee593bd-a1ad-4bab-b660-fda042e46ccf.png) | ![image](https://user-images.githubusercontent.com/3125580/189909056-4bfe9da0-9ebf-45a2-901f-860d3b84db04.png) |

* After (Linux & Windows, local)...

![image](https://user-images.githubusercontent.com/3125580/189991189-06e42239-434a-4b55-a94d-c50b26fdaba1.png)

### Context

Fixes #5 