### PR TITLE
[FEATURE-13]: support relators role notes as part of creators text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 package-lock.json
 *.txt
 *.json
+!lib/marcrelators/*.json

--- a/index.js
+++ b/index.js
@@ -230,7 +230,13 @@ function parseListItem(listItem) {
       }
       if (insideAuthors && i.type === "inlineCode") {
         // author role found. append rebuilding markdown format and then move on
+        const temp = entry.author.trim();
         entry.author += "`" + i.value + "`";
+        // relator term should be valid and at the start of each creator chunk, so check previous
+        if (temp.length > 0 && !temp.endsWith(",")) {
+          entry.manualReviewRequired = true; // mark for view and edit manually
+          entry.hasAuthorWarnings = true; // mark the reason
+        }
       }
       if (
         i.type === "emphasis" &&
@@ -290,8 +296,19 @@ function parseListItem(listItem) {
     }
   }
 
-  // if present, clean authors string
-  entry.author && (entry.author = entry.author.trim());
+  // if creator field is valued...
+  if (entry.author) {
+    // clean creators string
+    entry.author = entry.author.trim();
+    // ensure that creators not ends with invalid tokens
+    if (
+      // each creator delimiter || inlineCode relator term token
+      [",", "`"].some((token) => entry.author.endsWith(token))
+    ) {
+      entry.manualReviewRequired = true; // mark for view and edit manually
+      entry.hasAuthorWarnings = true; // mark the reason
+    }
+  }
 
   return entry;
 }

--- a/lib/functions/Functors.js
+++ b/lib/functions/Functors.js
@@ -1,0 +1,79 @@
+/**
+ * Function factory that builds a string case-insensitive predicate
+ *
+ * @param {string} str - the value to search
+ * @return {Predicate<string>} a Predicate function that receives a
+ *    string `value` which compare with and returns the comparing result
+ *    as boolean type, `true` if matches.
+ */
+function stringEqualsCaseInsensitivePredicate(str) {
+  return (/** @type string | null | undefined */ value) =>
+    value === str || // both raw same
+    // nullish-safe
+    (value !== null && // both not null
+      str !== null &&
+      value !== void 0 && // both defined
+      str !== void 0 &&
+      // both case-insensitive same
+      value.toLowerCase() === str.toLowerCase());
+}
+
+/**
+ * Function factory that builds a optional case-(in)sensitive comparator
+ * over a string or string object properties
+ *
+ * @param {string} propName - the property name to use as projection
+ * @param {boolean} caseInsensitive - if string comparision should be case insensitive.
+ *    Default: `false`
+ * @param {boolean} nullsFirst - if comparision should sort nullish values first.
+ *    Default: `true`
+ * @return {Comparator<T>} a Comparator function that receives two
+ *    string `value`s to compare with and returns the comparing result
+ *    as number type, `0` if both matches.
+ */
+function stringComparatorBy(
+  propName,
+  caseInsensitive = false,
+  nullsFirst = false
+) {
+  // handle overloaded functions...
+  if (typeof propName === "boolean") {
+    // ... stringComparatorBy(caseInsensitive)
+    if (arguments.length === 1) {
+      caseInsensitive = propName;
+      propName = void 0;
+    } // ... stringComparatorBy(caseInsensitive, nullsFirst)
+    else if (arguments.length >= 2) {
+      nullsFirst = caseInsensitive;
+      caseInsensitive = propName;
+      propName = void 0;
+    }
+  }
+  return (
+    /** @type T | null | undefined */ a,
+    /** @type T | null | undefined */ b
+  ) => {
+    // resolve property value
+    let va = propName ? a[propName] : a,
+      vb = propName ? b[propName] : b;
+    // compare values
+    if (va === vb) return 0; // both raw same
+    // sort nullish values (`null` or `undefined`) first if desired
+    if (va === null || va === void 0) {
+      return nullsFirst ? 1 : -1;
+    } else if (vb === null || vb === void 0) {
+      return nullsFirst ? -1 : 1;
+    }
+    // here is nullish-safe, so apply string comparator
+    if (caseInsensitive) {
+      va = va.toLowerCase();
+      vb = vb.toLowerCase();
+    }
+    return va.localeCompare(vb);
+  };
+}
+
+module.exports = {
+  stringEqualsCaseInsensitivePredicate,
+  stringComparatorBy,
+};

--- a/lib/functions/index.js
+++ b/lib/functions/index.js
@@ -1,7 +1,9 @@
 const Objects = require("./Objects");
 const Strings = require("./Strings");
+const Functors = require("./Functors");
 
 module.exports = {
   Objects,
   Strings,
+  Functors,
 };

--- a/lib/marcrelators/data.json
+++ b/lib/marcrelators/data.json
@@ -1,0 +1,1489 @@
+{
+  "abr": {
+    "code": "abr",
+    "name": "Abridger",
+    "note": "A person, family, or organization contributing to a resource by shortening or condensing the original work but leaving the nature and content of the original work substantially unchanged. For substantial modifications that result in the creation of a new work, see author"
+  },
+  "act": {
+    "code": "act",
+    "name": "Actor",
+    "note": "A performer contributing to an expression of a work by acting as a cast member or player in a musical or dramatic presentation, etc."
+  },
+  "adp": {
+    "code": "adp",
+    "name": "Adapter",
+    "note": "A person or organization who 1) reworks a musical composition, usually for a different medium, or 2) rewrites novels or stories for motion pictures or other audiovisual medium."
+  },
+  "rcp": {
+    "code": "rcp",
+    "name": "Addressee",
+    "note": "A person, family, or organization to whom the correspondence in a work is addressed",
+    "uf": [
+      "Recipient"
+    ]
+  },
+  "anl": {
+    "code": "anl",
+    "name": "Analyst",
+    "note": "A person or organization that reviews, examines and interprets data or information in a specific area"
+  },
+  "anm": {
+    "code": "anm",
+    "name": "Animator",
+    "note": "A person contributing to a moving image work or computer program by giving apparent movement to inanimate objects or drawings. For the creator of the drawings that are animated, see artist"
+  },
+  "ann": {
+    "code": "ann",
+    "name": "Annotator",
+    "note": "A person who makes manuscript annotations on an item"
+  },
+  "apl": {
+    "code": "apl",
+    "name": "Appellant",
+    "note": "A person or organization who appeals a lower court's decision"
+  },
+  "ape": {
+    "code": "ape",
+    "name": "Appellee",
+    "note": "A person or organization against whom an appeal is taken"
+  },
+  "app": {
+    "code": "app",
+    "name": "Applicant",
+    "note": "A person or organization responsible for the submission of an application or who is named as eligible for the results of the processing of the application (e.g., bestowing of rights, reward, title, position)"
+  },
+  "arc": {
+    "code": "arc",
+    "name": "Architect",
+    "note": "A person, family, or organization responsible for creating an architectural design, including a pictorial representation intended to show how a building, etc., will look when completed. It also oversees the construction of structures"
+  },
+  "arr": {
+    "code": "arr",
+    "name": "Arranger",
+    "note": "A person, family, or organization contributing to a musical work by rewriting the composition for a medium of performance different from that for which the work was originally intended, or modifying the work for the same medium of performance, etc., such that the musical substance of the original composition remains essentially unchanged. For extensive modification that effectively results in the creation of a new musical work, see composer",
+    "uf": [
+      "Arranger of music"
+    ]
+  },
+  "acp": {
+    "code": "acp",
+    "name": "Art copyist",
+    "note": "A person (e.g., a painter or sculptor) who makes copies of works of visual art"
+  },
+  "adi": {
+    "code": "adi",
+    "name": "Art director",
+    "note": "A person contributing to a motion picture or television production by overseeing the artists and craftspeople who build the sets"
+  },
+  "art": {
+    "code": "art",
+    "name": "Artist",
+    "note": "A person, family, or organization responsible for creating a work by conceiving, and implementing, an original graphic design, drawing, painting, etc. For book illustrators, prefer Illustrator [ill]",
+    "uf": [
+      "Graphic technician"
+    ]
+  },
+  "ard": {
+    "code": "ard",
+    "name": "Artistic director",
+    "note": "A person responsible for controlling the development of the artistic style of an entire production, including the choice of works to be presented and selection of senior production staff"
+  },
+  "asg": {
+    "code": "asg",
+    "name": "Assignee",
+    "note": "A person or organization to whom a license for printing or publishing has been transferred"
+  },
+  "asn": {
+    "code": "asn",
+    "name": "Associated name",
+    "note": "A person or organization associated with or found in an item or collection, which cannot be determined to be that of a Former owner [fmo] or other designated relationship indicative of provenance"
+  },
+  "att": {
+    "code": "att",
+    "name": "Attributed name",
+    "note": "An author, artist, etc., relating him/her to a resource for which there is or once was substantial authority for designating that person as author, creator, etc. of the work",
+    "uf": [
+      "Supposed name"
+    ]
+  },
+  "auc": {
+    "code": "auc",
+    "name": "Auctioneer",
+    "note": "A person or organization in charge of the estimation and public auctioning of goods, particularly books, artistic works, etc."
+  },
+  "aut": {
+    "code": "aut",
+    "name": "Author",
+    "note": "A person, family, or organization responsible for creating a work that is primarily textual in content, regardless of media type (e.g., printed text, spoken word, electronic text, tactile text) or genre (e.g., poems, novels, screenplays, blogs). Use also for persons, etc., creating a new work by paraphrasing, rewriting, or adapting works by another creator such that the modification has substantially changed the nature and content of the original or changed the medium of expression",
+    "uf": [
+      "Joint author"
+    ]
+  },
+  "aqt": {
+    "code": "aqt",
+    "name": "Author in quotations or text abstracts",
+    "note": "A person or organization whose work is largely quoted or extracted in works to which he or she did not contribute directly. Such quotations are found particularly in exhibition catalogs, collections of photographs, etc."
+  },
+  "aft": {
+    "code": "aft",
+    "name": "Author of afterword, colophon, etc.",
+    "note": "A person or organization responsible for an afterword, postface, colophon, etc. but who is not the chief author of a work"
+  },
+  "aud": {
+    "code": "aud",
+    "name": "Author of dialog",
+    "note": "A person or organization responsible for the dialog or spoken commentary for a screenplay or sound recording"
+  },
+  "aui": {
+    "code": "aui",
+    "name": "Author of introduction, etc.",
+    "note": "A person or organization responsible for an introduction, preface, foreword, or other critical introductory matter, but who is not the chief author"
+  },
+  "ato": {
+    "code": "ato",
+    "name": "Autographer",
+    "note": "A person whose manuscript signature appears on an item"
+  },
+  "ant": {
+    "code": "ant",
+    "name": "Bibliographic antecedent",
+    "note": "A person or organization responsible for a resource upon which the resource represented by the bibliographic description is based. This may be appropriate for adaptations, sequels, continuations, indexes, etc."
+  },
+  "bnd": {
+    "code": "bnd",
+    "name": "Binder",
+    "note": "A person who binds an item"
+  },
+  "bdd": {
+    "code": "bdd",
+    "name": "Binding designer",
+    "note": "A person or organization responsible for the binding design of a book, including the type of binding, the type of materials used, and any decorative aspects of the binding",
+    "uf": [
+      "Designer of binding"
+    ]
+  },
+  "blw": {
+    "code": "blw",
+    "name": "Blurb writer",
+    "note": "A person or organization responsible for writing a commendation or testimonial for a work, which appears on or within the publication itself, frequently on the back or dust jacket of print publications or on advertising material for all media"
+  },
+  "bkd": {
+    "code": "bkd",
+    "name": "Book designer",
+    "note": "A person or organization involved in manufacturing a manifestation by being responsible for the entire graphic design of a book, including arrangement of type and illustration, choice of materials, and process used",
+    "uf": [
+      "Designer of book",
+      "Designer of e-book"
+    ]
+  },
+  "bkp": {
+    "code": "bkp",
+    "name": "Book producer",
+    "note": "A person or organization responsible for the production of books and other print media",
+    "uf": [
+      "Producer of book"
+    ]
+  },
+  "bjd": {
+    "code": "bjd",
+    "name": "Bookjacket designer",
+    "note": "A person or organization responsible for the design of flexible covers designed for or published with a book, including the type of materials used, and any decorative aspects of the bookjacket",
+    "uf": [
+      "Designer of bookjacket"
+    ]
+  },
+  "bpd": {
+    "code": "bpd",
+    "name": "Bookplate designer",
+    "note": "A person or organization responsible for the design of a book owner's identification label that is most commonly pasted to the inside front cover of a book"
+  },
+  "bsl": {
+    "code": "bsl",
+    "name": "Bookseller",
+    "note": "A person or organization who makes books and other bibliographic materials available for purchase. Interest in the materials is primarily lucrative"
+  },
+  "brl": {
+    "code": "brl",
+    "name": "Braille embosser",
+    "note": "A person, family, or organization involved in manufacturing a resource by embossing Braille cells using a stylus, special embossing printer, or other device"
+  },
+  "brd": {
+    "code": "brd",
+    "name": "Broadcaster",
+    "note": "A person, family, or organization involved in broadcasting a resource to an audience via radio, television, webcast, etc."
+  },
+  "cll": {
+    "code": "cll",
+    "name": "Calligrapher",
+    "note": "A person or organization who writes in an artistic hand, usually as a copyist and or engrosser"
+  },
+  "ctg": {
+    "code": "ctg",
+    "name": "Cartographer",
+    "note": "A person, family, or organization responsible for creating a map, atlas, globe, or other cartographic work"
+  },
+  "cas": {
+    "code": "cas",
+    "name": "Caster",
+    "note": "A person, family, or organization involved in manufacturing a resource by pouring a liquid or molten substance into a mold and leaving it to solidify to take the shape of the mold"
+  },
+  "cns": {
+    "code": "cns",
+    "name": "Censor",
+    "note": "A person or organization who examines bibliographic resources for the purpose of suppressing parts deemed objectionable on moral, political, military, or other grounds",
+    "uf": [
+      "Bowdlerizer",
+      "Expurgator"
+    ]
+  },
+  "chr": {
+    "code": "chr",
+    "name": "Choreographer",
+    "note": "A person responsible for creating or contributing to a work of movement"
+  },
+  "cng": {
+    "code": "cng",
+    "name": "Cinematographer",
+    "note": "A person in charge of photographing a motion picture, who plans the technical aspets of lighting and photographing of scenes, and often assists the director in the choice of angles, camera setups, and lighting moods. He or she may also supervise the further processing of filmed material up to the completion of the work print. Cinematographer is also referred to as director of photography. Do not confuse with videographer",
+    "uf": [
+      "Director of photography"
+    ]
+  },
+  "cli": {
+    "code": "cli",
+    "name": "Client",
+    "note": "A person or organization for whom another person or organization is acting"
+  },
+  "cor": {
+    "code": "cor",
+    "name": "Collection registrar",
+    "note": "A curator who lists or inventories the items in an aggregate work such as a collection of items or works"
+  },
+  "col": {
+    "code": "col",
+    "name": "Collector",
+    "note": "A curator who brings together items from various sources that are then arranged, described, and cataloged as a collection. A collector is neither the creator of the material nor a person to whom manuscripts in the collection may have been addressed"
+  },
+  "clt": {
+    "code": "clt",
+    "name": "Collotyper",
+    "note": "A person, family, or organization involved in manufacturing a manifestation of photographic prints from film or other colloid that has ink-receptive and ink-repellent surfaces"
+  },
+  "clr": {
+    "code": "clr",
+    "name": "Colorist",
+    "note": "A person or organization responsible for applying color to drawings, prints, photographs, maps, moving images, etc"
+  },
+  "cmm": {
+    "code": "cmm",
+    "name": "Commentator",
+    "note": "A performer contributing to a work by providing interpretation, analysis, or a discussion of the subject matter on a recording, film, or other audiovisual medium"
+  },
+  "cwt": {
+    "code": "cwt",
+    "name": "Commentator for written text",
+    "note": "A person or organization responsible for the commentary or explanatory notes about a text. For the writer of manuscript annotations in a printed book, use Annotator"
+  },
+  "com": {
+    "code": "com",
+    "name": "Compiler",
+    "note": "A person, family, or organization responsible for creating a new work (e.g., a bibliography, a directory) through the act of compilation, e.g., selecting, arranging, aggregating, and editing data, information, etc"
+  },
+  "cpl": {
+    "code": "cpl",
+    "name": "Complainant",
+    "note": "A person or organization who applies to the courts for redress, usually in an equity proceeding"
+  },
+  "cpt": {
+    "code": "cpt",
+    "name": "Complainant-appellant",
+    "note": "A complainant who takes an appeal from one court or jurisdiction to another to reverse the judgment, usually in an equity proceeding"
+  },
+  "cpe": {
+    "code": "cpe",
+    "name": "Complainant-appellee",
+    "note": "A complainant against whom an appeal is taken from one court or jurisdiction to another to reverse the judgment, usually in an equity proceeding"
+  },
+  "cmp": {
+    "code": "cmp",
+    "name": "Composer",
+    "note": "A person, family, or organization responsible for creating or contributing to a musical resource by adding music to a work that originally lacked it or supplements it"
+  },
+  "cmt": {
+    "code": "cmt",
+    "name": "Compositor",
+    "note": "A person or organization responsible for the creation of metal slug, or molds made of other materials, used to produce the text and images in printed matter",
+    "uf": [
+      "Typesetter"
+    ]
+  },
+  "ccp": {
+    "code": "ccp",
+    "name": "Conceptor",
+    "note": "A person or organization responsible for the original idea on which a work is based, this includes the scientific author of an audio-visual item and the conceptor of an advertisement"
+  },
+  "cnd": {
+    "code": "cnd",
+    "name": "Conductor",
+    "note": "A performer contributing to a musical resource by leading a performing group (orchestra, chorus, opera, etc.) in a musical or dramatic presentation, etc."
+  },
+  "con": {
+    "code": "con",
+    "name": "Conservator",
+    "note": "A person or organization responsible for documenting, preserving, or treating printed or manuscript material, works of art, artifacts, or other media",
+    "uf": [
+      "Preservationist"
+    ]
+  },
+  "csl": {
+    "code": "csl",
+    "name": "Consultant",
+    "note": "A person or organization relevant to a resource, who is called upon for professional advice or services in a specialized field of knowledge or training"
+  },
+  "csp": {
+    "code": "csp",
+    "name": "Consultant to a project",
+    "note": "A person or organization relevant to a resource, who is engaged specifically to provide an intellectual overview of a strategic or operational task and by analysis, specification, or instruction, to create or propose a cost-effective course of action or solution"
+  },
+  "cos": {
+    "code": "cos",
+    "name": "Contestant",
+    "note": "A person(s) or organization who opposes, resists, or disputes, in a court of law, a claim, decision, result, etc."
+  },
+  "cot": {
+    "code": "cot",
+    "name": "Contestant-appellant",
+    "note": "A contestant who takes an appeal from one court of law or jurisdiction to another to reverse the judgment"
+  },
+  "coe": {
+    "code": "coe",
+    "name": "Contestant-appellee",
+    "note": "A contestant against whom an appeal is taken from one court of law or jurisdiction to another to reverse the judgment"
+  },
+  "cts": {
+    "code": "cts",
+    "name": "Contestee",
+    "note": "A person(s) or organization defending a claim, decision, result, etc. being opposed, resisted, or disputed in a court of law"
+  },
+  "ctt": {
+    "code": "ctt",
+    "name": "Contestee-appellant",
+    "note": "A contestee who takes an appeal from one court or jurisdiction to another to reverse the judgment"
+  },
+  "cte": {
+    "code": "cte",
+    "name": "Contestee-appellee",
+    "note": "A contestee against whom an appeal is taken from one court or jurisdiction to another to reverse the judgment"
+  },
+  "ctr": {
+    "code": "ctr",
+    "name": "Contractor",
+    "note": "A person or organization relevant to a resource, who enters into a contract with another person or organization to perform a specific"
+  },
+  "ctb": {
+    "code": "ctb",
+    "name": "Contributor",
+    "note": "A person, family or organization responsible for making contributions to the resource. This includes those whose work has been contributed to a larger work, such as an anthology, serial publication, or other compilation of individual works. If a more specific role is available, prefer that, e.g. editor, compiler, illustrator",
+    "uf": [
+      "Collaborator"
+    ]
+  },
+  "cpc": {
+    "code": "cpc",
+    "name": "Copyright claimant",
+    "note": "A person or organization listed as a copyright owner at the time of registration. Copyright can be granted or later transferred to another person or organization, at which time the claimant becomes the copyright holder"
+  },
+  "cph": {
+    "code": "cph",
+    "name": "Copyright holder",
+    "note": "A person or organization to whom copy and legal rights have been granted or transferred for the intellectual content of a work. The copyright holder, although not necessarily the creator of the work, usually has the exclusive right to benefit financially from the sale and use of the work to which the associated copyright protection applies"
+  },
+  "crr": {
+    "code": "crr",
+    "name": "Corrector",
+    "note": "A person or organization who is a corrector of manuscripts, such as the scriptorium official who corrected the work of a scribe. For printed matter, use Proofreader"
+  },
+  "crp": {
+    "code": "crp",
+    "name": "Correspondent",
+    "note": "A person or organization who was either the writer or recipient of a letter or other communication"
+  },
+  "cst": {
+    "code": "cst",
+    "name": "Costume designer",
+    "note": "A person, family, or organization that designs the costumes for a moving image production or for a musical or dramatic presentation or entertainment"
+  },
+  "cou": {
+    "code": "cou",
+    "name": "Court governed",
+    "note": "A court governed by court rules, regardless of their official nature (e.g., laws, administrative regulations)"
+  },
+  "crt": {
+    "code": "crt",
+    "name": "Court reporter",
+    "note": "A person, family, or organization contributing to a resource by preparing a court's opinions for publication"
+  },
+  "cov": {
+    "code": "cov",
+    "name": "Cover designer",
+    "note": "A person or organization responsible for the graphic design of a book cover, album cover, slipcase, box, container, etc. For a person or organization responsible for the graphic design of an entire book, use Book designer; for book jackets, use Bookjacket designer",
+    "uf": [
+      "Designer of cover"
+    ]
+  },
+  "cre": {
+    "code": "cre",
+    "name": "Creator",
+    "note": "A person or organization responsible for the intellectual or artistic content of a resource"
+  },
+  "cur": {
+    "code": "cur",
+    "name": "Curator",
+    "note": "A person, family, or organization conceiving, aggregating, and/or organizing an exhibition, collection, or other item",
+    "uf": [
+      "Curator of an exhibition"
+    ]
+  },
+  "dnc": {
+    "code": "dnc",
+    "name": "Dancer",
+    "note": "A performer who dances in a musical, dramatic, etc., presentation"
+  },
+  "dtc": {
+    "code": "dtc",
+    "name": "Data contributor",
+    "note": "A person or organization that submits data for inclusion in a database or other collection of data"
+  },
+  "dtm": {
+    "code": "dtm",
+    "name": "Data manager",
+    "note": "A person or organization responsible for managing databases or other data sources"
+  },
+  "dte": {
+    "code": "dte",
+    "name": "Dedicatee",
+    "note": "A person, family, or organization to whom a resource is dedicated",
+    "uf": [
+      "Dedicatee of item"
+    ]
+  },
+  "dto": {
+    "code": "dto",
+    "name": "Dedicator",
+    "note": "A person who writes a dedication, which may be a formal statement or in epistolary or verse form"
+  },
+  "dfd": {
+    "code": "dfd",
+    "name": "Defendant",
+    "note": "A person or organization who is accused in a criminal proceeding or sued in a civil proceeding"
+  },
+  "dft": {
+    "code": "dft",
+    "name": "Defendant-appellant",
+    "note": "A defendant who takes an appeal from one court or jurisdiction to another to reverse the judgment, usually in a legal action"
+  },
+  "dfe": {
+    "code": "dfe",
+    "name": "Defendant-appellee",
+    "note": "A defendant against whom an appeal is taken from one court or jurisdiction to another to reverse the judgment, usually in a legal action"
+  },
+  "dgc": {
+    "code": "dgc",
+    "name": "Degree committee member",
+    "note": "A person who is part of a committee that considers the merit of a thesis, dissertation, or other submission by an academic degree candidate."
+  },
+  "dgg": {
+    "code": "dgg",
+    "name": "Degree granting institution",
+    "note": "A organization granting an academic degree",
+    "uf": [
+      "Degree grantor"
+    ]
+  },
+  "dgs": {
+    "code": "dgs",
+    "name": "Degree supervisor",
+    "note": "A person overseeing a higher level academic degree"
+  },
+  "dln": {
+    "code": "dln",
+    "name": "Delineator",
+    "note": "A person or organization executing technical drawings from others' designs"
+  },
+  "dpc": {
+    "code": "dpc",
+    "name": "Depicted",
+    "note": "An entity depicted or portrayed in a work, particularly in a work of art"
+  },
+  "dpt": {
+    "code": "dpt",
+    "name": "Depositor",
+    "note": "A current owner of an item who deposited the item into the custody of another person, family, or organization, while still retaining ownership"
+  },
+  "dsr": {
+    "code": "dsr",
+    "name": "Designer",
+    "note": "A person, family, or organization responsible for creating a design for an object"
+  },
+  "drt": {
+    "code": "drt",
+    "name": "Director",
+    "note": "A person responsible for the general management and supervision of a filmed performance, a radio or television program, etc."
+  },
+  "dis": {
+    "code": "dis",
+    "name": "Dissertant",
+    "note": "A person who presents a thesis for a university or higher-level educational degree"
+  },
+  "dbp": {
+    "code": "dbp",
+    "name": "Distribution place",
+    "note": "A place from which a resource, e.g., a serial, is distributed"
+  },
+  "dst": {
+    "code": "dst",
+    "name": "Distributor",
+    "note": "A person or organization that has exclusive or shared marketing rights for a resource"
+  },
+  "dnr": {
+    "code": "dnr",
+    "name": "Donor",
+    "note": "A former owner of an item who donated that item to another owner"
+  },
+  "drm": {
+    "code": "drm",
+    "name": "Draftsman",
+    "note": "A person, family, or organization contributing to a resource by an architect, inventor, etc., by making detailed plans or drawings for buildings, ships, aircraft, machines, objects, etc",
+    "uf": [
+      "Technical draftsman"
+    ]
+  },
+  "dub": {
+    "code": "dub",
+    "name": "Dubious author",
+    "note": "A person or organization to which authorship has been dubiously or incorrectly ascribed"
+  },
+  "edt": {
+    "code": "edt",
+    "name": "Editor",
+    "note": "A person, family, or organization contributing to a resource by revising or elucidating the content, e.g., adding an introduction, notes, or other critical matter. An editor may also prepare a resource for production, publication, or distribution. For major revisions, adaptations, etc., that substantially change the nature and content of the original work, resulting in a new work, see author"
+  },
+  "edc": {
+    "code": "edc",
+    "name": "Editor of compilation",
+    "note": "A person, family, or organization contributing to a collective or aggregate work by selecting and putting together works, or parts of works, by one or more creators. For compilations of data, information, etc., that result in new works, see compiler"
+  },
+  "edm": {
+    "code": "edm",
+    "name": "Editor of moving image work",
+    "note": "A person, family, or organization responsible for assembling, arranging, and trimming film, video, or other moving image formats, including both visual and audio aspects",
+    "uf": [
+      "Moving image work editor"
+    ]
+  },
+  "elg": {
+    "code": "elg",
+    "name": "Electrician",
+    "note": "A person responsible for setting up a lighting rig and focusing the lights for a production, and running the lighting at a performance",
+    "uf": [
+      "Chief electrician",
+      "House electrician",
+      "Master electrician"
+    ]
+  },
+  "elt": {
+    "code": "elt",
+    "name": "Electrotyper",
+    "note": "A person or organization who creates a duplicate printing surface by pressure molding and electrodepositing of metal that is then backed up with lead for printing"
+  },
+  "enj": {
+    "code": "enj",
+    "name": "Enacting jurisdiction",
+    "note": "A jurisdiction enacting a law, regulation, constitution, court rule, etc."
+  },
+  "eng": {
+    "code": "eng",
+    "name": "Engineer",
+    "note": "A person or organization that is responsible for technical planning and design, particularly with construction"
+  },
+  "egr": {
+    "code": "egr",
+    "name": "Engraver",
+    "note": "A person or organization who cuts letters, figures, etc. on a surface, such as a wooden or metal plate used for printing"
+  },
+  "etr": {
+    "code": "etr",
+    "name": "Etcher",
+    "note": "A person or organization who produces text or images for printing by subjecting metal, glass, or some other surface to acid or the corrosive action of some other substance"
+  },
+  "evp": {
+    "code": "evp",
+    "name": "Event place",
+    "note": "A place where an event such as a conference or a concert took place"
+  },
+  "exp": {
+    "code": "exp",
+    "name": "Expert",
+    "note": "A person or organization in charge of the description and appraisal of the value of goods, particularly rare items, works of art, etc.",
+    "uf": [
+      "Appraiser"
+    ]
+  },
+  "fac": {
+    "code": "fac",
+    "name": "Facsimilist",
+    "note": "A person or organization that executed the facsimile",
+    "uf": [
+      "Copier"
+    ]
+  },
+  "fld": {
+    "code": "fld",
+    "name": "Field director",
+    "note": "A person or organization that manages or supervises the work done to collect raw data or do research in an actual setting or environment (typically applies to the natural and social sciences)"
+  },
+  "fmd": {
+    "code": "fmd",
+    "name": "Film director",
+    "note": "A director responsible for the general management and supervision of a filmed performance"
+  },
+  "fds": {
+    "code": "fds",
+    "name": "Film distributor",
+    "note": "A person, family, or organization involved in distributing a moving image resource to theatres or other distribution channels"
+  },
+  "flm": {
+    "code": "flm",
+    "name": "Film editor",
+    "note": "A person who, following the script and in creative cooperation with the Director, selects, arranges, and assembles the filmed material, controls the synchronization of picture and sound, and participates in other post-production tasks such as sound mixing and visual effects processing. Today, picture editing is often performed digitally.",
+    "uf": [
+      "Motion picture editor"
+    ]
+  },
+  "fmp": {
+    "code": "fmp",
+    "name": "Film producer",
+    "note": "A producer responsible for most of the business aspects of a film"
+  },
+  "fmk": {
+    "code": "fmk",
+    "name": "Filmmaker",
+    "note": "A person, family or organization responsible for creating an independent or personal film. A filmmaker is individually responsible for the conception and execution of all aspects of the film"
+  },
+  "fpy": {
+    "code": "fpy",
+    "name": "First party",
+    "note": "A person or organization who is identified as the only party or the party of the first party. In the case of transfer of rights, this is the assignor, transferor, licensor, grantor, etc. Multiple parties can be named jointly as the first party"
+  },
+  "frg": {
+    "code": "frg",
+    "name": "Forger",
+    "note": "A person or organization who makes or imitates something of value or importance, especially with the intent to defraud",
+    "uf": [
+      "Copier",
+      "Counterfeiter"
+    ]
+  },
+  "fmo": {
+    "code": "fmo",
+    "name": "Former owner",
+    "note": "A person, family, or organization formerly having legal possession of an item"
+  },
+  "fnd": {
+    "code": "fnd",
+    "name": "Funder",
+    "note": "A person or organization that furnished financial support for the production of the work"
+  },
+  "gis": {
+    "code": "gis",
+    "name": "Geographic information specialist",
+    "note": "A person responsible for geographic information system (GIS) development and integration with global positioning system data",
+    "uf": [
+      "Geospatial information specialist"
+    ]
+  },
+  "hnr": {
+    "code": "hnr",
+    "name": "Honoree",
+    "note": "A person, family, or organization honored by a work or item (e.g., the honoree of a festschrift, a person to whom a copy is presented)",
+    "uf": [
+      "Honouree",
+      "Honouree of item"
+    ]
+  },
+  "hst": {
+    "code": "hst",
+    "name": "Host",
+    "note": "A performer contributing to a resource by leading a program (often broadcast) that includes other guests, performers, etc. (e.g., talk show host)"
+  },
+  "his": {
+    "code": "his",
+    "name": "Host institution",
+    "note": "An organization hosting the event, exhibit, conference, etc., which gave rise to a resource, but having little or no responsibility for the content of the resource"
+  },
+  "ilu": {
+    "code": "ilu",
+    "name": "Illuminator",
+    "note": "A person providing decoration to a specific item using precious metals or color, often with elaborate designs and motifs"
+  },
+  "ill": {
+    "code": "ill",
+    "name": "Illustrator",
+    "note": "A person, family, or organization contributing to a resource by supplementing the primary content with drawings, diagrams, photographs, etc. If the work is primarily the artistic content created by this entity, use artist or photographer"
+  },
+  "ins": {
+    "code": "ins",
+    "name": "Inscriber",
+    "note": "A person who has written a statement of dedication or gift"
+  },
+  "itr": {
+    "code": "itr",
+    "name": "Instrumentalist",
+    "note": "A performer contributing to a resource by playing a musical instrument"
+  },
+  "ive": {
+    "code": "ive",
+    "name": "Interviewee",
+    "note": "A person, family or organization responsible for creating or contributing to a resource by responding to an interviewer, usually a reporter, pollster, or some other information gathering agent"
+  },
+  "ivr": {
+    "code": "ivr",
+    "name": "Interviewer",
+    "note": "A person, family, or organization responsible for creating or contributing to a resource by acting as an interviewer, reporter, pollster, or some other information gathering agent"
+  },
+  "inv": {
+    "code": "inv",
+    "name": "Inventor",
+    "note": "A person, family, or organization responsible for creating a new device or process",
+    "uf": [
+      "Patent inventor"
+    ]
+  },
+  "isb": {
+    "code": "isb",
+    "name": "Issuing body",
+    "note": "A person, family or organization issuing a work, such as an official organ of the body"
+  },
+  "jud": {
+    "code": "jud",
+    "name": "Judge",
+    "note": "A person who hears and decides on legal matters in court."
+  },
+  "jug": {
+    "code": "jug",
+    "name": "Jurisdiction governed",
+    "note": "A jurisdiction governed by a law, regulation, etc., that was enacted by another jurisdiction"
+  },
+  "lbr": {
+    "code": "lbr",
+    "name": "Laboratory",
+    "note": "An organization that provides scientific analyses of material samples"
+  },
+  "ldr": {
+    "code": "ldr",
+    "name": "Laboratory director",
+    "note": "A person or organization that manages or supervises work done in a controlled setting or environment",
+    "uf": [
+      "Lab director"
+    ]
+  },
+  "lsa": {
+    "code": "lsa",
+    "name": "Landscape architect",
+    "note": "An architect responsible for creating landscape works. This work involves coordinating the arrangement of existing and proposed land features and structures"
+  },
+  "led": {
+    "code": "led",
+    "name": "Lead",
+    "note": "A person or organization that takes primary responsibility for a particular activity or endeavor. May be combined with another relator term or code to show the greater importance this person or organization has regarding that particular role. If more than one relator is assigned to a heading, use the Lead relator only if it applies to all the relators"
+  },
+  "len": {
+    "code": "len",
+    "name": "Lender",
+    "note": "A person or organization permitting the temporary use of a book, manuscript, etc., such as for photocopying or microfilming"
+  },
+  "lil": {
+    "code": "lil",
+    "name": "Libelant",
+    "note": "A person or organization who files a libel in an ecclesiastical or admiralty case"
+  },
+  "lit": {
+    "code": "lit",
+    "name": "Libelant-appellant",
+    "note": "A libelant who takes an appeal from one ecclesiastical court or admiralty to another to reverse the judgment"
+  },
+  "lie": {
+    "code": "lie",
+    "name": "Libelant-appellee",
+    "note": "A libelant against whom an appeal is taken from one ecclesiastical court or admiralty to another to reverse the judgment"
+  },
+  "lel": {
+    "code": "lel",
+    "name": "Libelee",
+    "note": "A person or organization against whom a libel has been filed in an ecclesiastical court or admiralty"
+  },
+  "let": {
+    "code": "let",
+    "name": "Libelee-appellant",
+    "note": "A libelee who takes an appeal from one ecclesiastical court or admiralty to another to reverse the judgment"
+  },
+  "lee": {
+    "code": "lee",
+    "name": "Libelee-appellee",
+    "note": "A libelee against whom an appeal is taken from one ecclesiastical court or admiralty to another to reverse the judgment"
+  },
+  "lbt": {
+    "code": "lbt",
+    "name": "Librettist",
+    "note": "An author of a libretto of an opera or other stage work, or an oratorio"
+  },
+  "lse": {
+    "code": "lse",
+    "name": "Licensee",
+    "note": "A person or organization who is an original recipient of the right to print or publish"
+  },
+  "lso": {
+    "code": "lso",
+    "name": "Licensor",
+    "note": "A person or organization who is a signer of the license, imprimatur, etc",
+    "uf": [
+      "Imprimatur"
+    ]
+  },
+  "lgd": {
+    "code": "lgd",
+    "name": "Lighting designer",
+    "note": "A person or organization who designs the lighting scheme for a theatrical presentation, entertainment, motion picture, etc."
+  },
+  "ltg": {
+    "code": "ltg",
+    "name": "Lithographer",
+    "note": "A person or organization who prepares the stone or plate for lithographic printing, including a graphic artist creating a design directly on the surface from which printing will be done."
+  },
+  "lyr": {
+    "code": "lyr",
+    "name": "Lyricist",
+    "note": "An author of the words of a non-dramatic musical work (e.g. the text of a song), except for oratorios"
+  },
+  "mfp": {
+    "code": "mfp",
+    "name": "Manufacture place",
+    "note": "The place of manufacture (e.g., printing, duplicating, casting, etc.) of a resource in a published form"
+  },
+  "mfr": {
+    "code": "mfr",
+    "name": "Manufacturer",
+    "note": "A person or organization responsible for printing, duplicating, casting, etc. a resource"
+  },
+  "mrb": {
+    "code": "mrb",
+    "name": "Marbler",
+    "note": "The entity responsible for marbling paper, cloth, leather, etc. used in construction of a resource"
+  },
+  "mrk": {
+    "code": "mrk",
+    "name": "Markup editor",
+    "note": "A person or organization performing the coding of SGML, HTML, or XML markup of metadata, text, etc.",
+    "uf": [
+      "Encoder"
+    ]
+  },
+  "med": {
+    "code": "med",
+    "name": "Medium",
+    "note": "A person held to be a channel of communication between the earthly world and a world of spirits"
+  },
+  "mdc": {
+    "code": "mdc",
+    "name": "Metadata contact",
+    "note": "A person or organization primarily responsible for compiling and maintaining the original description of a metadata set (e.g., geospatial metadata set)"
+  },
+  "mte": {
+    "code": "mte",
+    "name": "Metal-engraver",
+    "note": "An engraver responsible for decorations, illustrations, letters, etc. cut on a metal surface for printing or decoration"
+  },
+  "mtk": {
+    "code": "mtk",
+    "name": "Minute taker",
+    "note": "A person, family, or organization responsible for recording the minutes of a meeting"
+  },
+  "mod": {
+    "code": "mod",
+    "name": "Moderator",
+    "note": "A performer contributing to a resource by leading a program (often broadcast) where topics are discussed, usually with participation of experts in fields related to the discussion"
+  },
+  "mon": {
+    "code": "mon",
+    "name": "Monitor",
+    "note": "A person or organization that supervises compliance with the contract and is responsible for the report and controls its distribution. Sometimes referred to as the grantee, or controlling agency"
+  },
+  "mcp": {
+    "code": "mcp",
+    "name": "Music copyist",
+    "note": "A person who transcribes or copies musical notation"
+  },
+  "msd": {
+    "code": "msd",
+    "name": "Musical director",
+    "note": "A person who coordinates the activities of the composer, the sound editor, and sound mixers for a moving image production or for a musical or dramatic presentation or entertainment"
+  },
+  "mus": {
+    "code": "mus",
+    "name": "Musician",
+    "note": "A person or organization who performs music or contributes to the musical content of a work when it is not possible or desirable to identify the function more precisely"
+  },
+  "nrt": {
+    "code": "nrt",
+    "name": "Narrator",
+    "note": "A performer contributing to a resource by reading or speaking in order to give an account of an act, occurrence, course of events, etc"
+  },
+  "osp": {
+    "code": "osp",
+    "name": "Onscreen presenter",
+    "note": "A performer contributing to an expression of a work by appearing on screen in nonfiction moving image materials or introductions to fiction moving image materials to provide contextual or background information. Use when another term (e.g., narrator, host) is either not applicable or not desired"
+  },
+  "opn": {
+    "code": "opn",
+    "name": "Opponent",
+    "note": "A person or organization responsible for opposing a thesis or dissertation"
+  },
+  "orm": {
+    "code": "orm",
+    "name": "Organizer",
+    "note": "A person, family, or organization organizing the exhibit, event, conference, etc., which gave rise to a resource",
+    "uf": [
+      "Organizer of meeting"
+    ]
+  },
+  "org": {
+    "code": "org",
+    "name": "Originator",
+    "note": "A person or organization performing the work, i.e., the name of a person or organization associated with the intellectual content of the work. This category does not include the publisher or personal affiliation, or sponsor except where it is also the corporate author"
+  },
+  "oth": {
+    "code": "oth",
+    "name": "Other",
+    "note": "A role that has no equivalent in the MARC list."
+  },
+  "own": {
+    "code": "own",
+    "name": "Owner",
+    "note": "A person, family, or organization that currently owns an item or collection, i.e.has legal possession of a resource",
+    "uf": [
+      "Current owner"
+    ]
+  },
+  "pan": {
+    "code": "pan",
+    "name": "Panelist",
+    "note": "A performer contributing to a resource by participating in a program (often broadcast) where topics are discussed, usually with participation of experts in fields related to the discussion"
+  },
+  "ppm": {
+    "code": "ppm",
+    "name": "Papermaker",
+    "note": "A person or organization responsible for the production of paper, usually from wood, cloth, or other fibrous material"
+  },
+  "pta": {
+    "code": "pta",
+    "name": "Patent applicant",
+    "note": "A person or organization that applied for a patent"
+  },
+  "pth": {
+    "code": "pth",
+    "name": "Patent holder",
+    "note": "A person or organization that was granted the patent referred to by the item",
+    "uf": [
+      "Patentee"
+    ]
+  },
+  "pat": {
+    "code": "pat",
+    "name": "Patron",
+    "note": "A person or organization responsible for commissioning a work. Usually a patron uses his or her means or influence to support the work of artists, writers, etc. This includes those who commission and pay for individual works"
+  },
+  "prf": {
+    "code": "prf",
+    "name": "Performer",
+    "note": "A person contributing to a resource by performing music, acting, dancing, speaking, etc., often in a musical or dramatic presentation, etc. If specific codes are used, [prf] is used for a person whose principal skill is not known or specified"
+  },
+  "pma": {
+    "code": "pma",
+    "name": "Permitting agency",
+    "note": "An organization (usually a government agency) that issues permits under which work is accomplished"
+  },
+  "pht": {
+    "code": "pht",
+    "name": "Photographer",
+    "note": "A person, family, or organization responsible for creating a photographic work"
+  },
+  "pad": {
+    "code": "pad",
+    "name": "Place of address",
+    "note": "The place to which a resource is sent, for example, the place of the postal address of a letter"
+  },
+  "ptf": {
+    "code": "ptf",
+    "name": "Plaintiff",
+    "note": "A person or organization who brings a suit in a civil proceeding"
+  },
+  "ptt": {
+    "code": "ptt",
+    "name": "Plaintiff-appellant",
+    "note": "A plaintiff who takes an appeal from one court or jurisdiction to another to reverse the judgment, usually in a legal proceeding"
+  },
+  "pte": {
+    "code": "pte",
+    "name": "Plaintiff-appellee",
+    "note": "A plaintiff against whom an appeal is taken from one court or jurisdiction to another to reverse the judgment, usually in a legal proceeding"
+  },
+  "plt": {
+    "code": "plt",
+    "name": "Platemaker",
+    "note": "A person, family, or organization involved in manufacturing a manifestation by preparing plates used in the production of printed images and/or text"
+  },
+  "pra": {
+    "code": "pra",
+    "name": "Praeses",
+    "note": "A person who is the faculty moderator of an academic disputation, normally proposing a thesis and participating in the ensuing disputation"
+  },
+  "pre": {
+    "code": "pre",
+    "name": "Presenter",
+    "note": "A person or organization mentioned in an “X presents” credit for moving image materials and who is associated with production, finance, or distribution in some way. A vanity credit; in early years, normally the head of a studio"
+  },
+  "prt": {
+    "code": "prt",
+    "name": "Printer",
+    "note": "A person, family, or organization involved in manufacturing a manifestation of printed text, notated music, etc., from type or plates, such as a book, newspaper, magazine, broadside, score, etc"
+  },
+  "pop": {
+    "code": "pop",
+    "name": "Printer of plates",
+    "note": "A person or organization who prints illustrations from plates.",
+    "uf": [
+      "Plates, printer of"
+    ]
+  },
+  "prm": {
+    "code": "prm",
+    "name": "Printmaker",
+    "note": "A person or organization who makes a relief, intaglio, or planographic printing surface"
+  },
+  "prc": {
+    "code": "prc",
+    "name": "Process contact",
+    "note": "A person or organization primarily responsible for performing or initiating a process, such as is done with the collection of metadata sets"
+  },
+  "pro": {
+    "code": "pro",
+    "name": "Producer",
+    "note": "A person, family, or organization responsible for most of the business aspects of a production for screen, audio recording, television, webcast, etc. The producer is generally responsible for fund raising, managing the production, hiring key personnel, arranging for distributors, etc."
+  },
+  "prn": {
+    "code": "prn",
+    "name": "Production company",
+    "note": "An organization that is responsible for financial, technical, and organizational management of a production for stage, screen, audio recording, television, webcast, etc."
+  },
+  "prs": {
+    "code": "prs",
+    "name": "Production designer",
+    "note": "A person or organization responsible for designing the overall visual appearance of a moving image production"
+  },
+  "pmn": {
+    "code": "pmn",
+    "name": "Production manager",
+    "note": "A person responsible for all technical and business matters in a production"
+  },
+  "prd": {
+    "code": "prd",
+    "name": "Production personnel",
+    "note": "A person or organization associated with the production (props, lighting, special effects, etc.) of a musical or dramatic presentation or entertainment"
+  },
+  "prp": {
+    "code": "prp",
+    "name": "Production place",
+    "note": "The place of production (e.g., inscription, fabrication, construction, etc.) of a resource in an unpublished form"
+  },
+  "prg": {
+    "code": "prg",
+    "name": "Programmer",
+    "note": "A person, family, or organization responsible for creating a computer program"
+  },
+  "pdr": {
+    "code": "pdr",
+    "name": "Project director",
+    "note": "A person or organization with primary responsibility for all essential aspects of a project, has overall responsibility for managing projects, or provides overall direction to a project manager"
+  },
+  "pfr": {
+    "code": "pfr",
+    "name": "Proofreader",
+    "note": "A person who corrects printed matter. For manuscripts, use Corrector [crr]"
+  },
+  "prv": {
+    "code": "prv",
+    "name": "Provider",
+    "note": "A person or organization who produces, publishes, manufactures, or distributes a resource if specific codes are not desired (e.g. [mfr], [pbl])"
+  },
+  "pup": {
+    "code": "pup",
+    "name": "Publication place",
+    "note": "The place where a resource is published"
+  },
+  "pbl": {
+    "code": "pbl",
+    "name": "Publisher",
+    "note": "A person or organization responsible for publishing, releasing, or issuing a resource"
+  },
+  "pbd": {
+    "code": "pbd",
+    "name": "Publishing director",
+    "note": "A person or organization who presides over the elaboration of a collective work to ensure its coherence or continuity. This includes editors-in-chief, literary editors, editors of series, etc."
+  },
+  "ppt": {
+    "code": "ppt",
+    "name": "Puppeteer",
+    "note": "A performer contributing to a resource by manipulating, controlling, or directing puppets or marionettes in a moving image production or a musical or dramatic presentation or entertainment"
+  },
+  "rdd": {
+    "code": "rdd",
+    "name": "Radio director",
+    "note": "A director responsible for the general management and supervision of a radio program"
+  },
+  "rpc": {
+    "code": "rpc",
+    "name": "Radio producer",
+    "note": "A producer responsible for most of the business aspects of a radio program"
+  },
+  "rce": {
+    "code": "rce",
+    "name": "Recording engineer",
+    "note": "A person contributing to a resource by supervising the technical aspects of a sound or video recording session"
+  },
+  "rcd": {
+    "code": "rcd",
+    "name": "Recordist",
+    "note": "A person or organization who uses a recording device to capture sounds and/or video during a recording session, including field recordings of natural sounds, folkloric events, music, etc."
+  },
+  "red": {
+    "code": "red",
+    "name": "Redaktor",
+    "note": "A person or organization who writes or develops the framework for an item without being intellectually responsible for its content"
+  },
+  "ren": {
+    "code": "ren",
+    "name": "Renderer",
+    "note": "A person or organization who prepares drawings of architectural designs (i.e., renderings) in accurate, representational perspective to show what the project will look like when completed"
+  },
+  "rpt": {
+    "code": "rpt",
+    "name": "Reporter",
+    "note": "A person or organization who writes or presents reports of news or current events on air or in print"
+  },
+  "rps": {
+    "code": "rps",
+    "name": "Repository",
+    "note": "An organization that hosts data or material culture objects and provides services to promote long term, consistent and shared use of those data or objects"
+  },
+  "rth": {
+    "code": "rth",
+    "name": "Research team head",
+    "note": "A person who directed or managed a research project"
+  },
+  "rtm": {
+    "code": "rtm",
+    "name": "Research team member",
+    "note": "A person who participated in a research project but whose role did not involve direction or management of it"
+  },
+  "res": {
+    "code": "res",
+    "name": "Researcher",
+    "note": "A person or organization responsible for performing research",
+    "uf": [
+      "Performer of research"
+    ]
+  },
+  "rsp": {
+    "code": "rsp",
+    "name": "Respondent",
+    "note": "A person or organization who makes an answer to the courts pursuant to an application for redress (usually in an equity proceeding) or a candidate for a degree who defends or opposes a thesis provided by the praeses in an academic disputation"
+  },
+  "rst": {
+    "code": "rst",
+    "name": "Respondent-appellant",
+    "note": "A respondent who takes an appeal from one court or jurisdiction to another to reverse the judgment, usually in an equity proceeding"
+  },
+  "rse": {
+    "code": "rse",
+    "name": "Respondent-appellee",
+    "note": "A respondent against whom an appeal is taken from one court or jurisdiction to another to reverse the judgment, usually in an equity proceeding"
+  },
+  "rpy": {
+    "code": "rpy",
+    "name": "Responsible party",
+    "note": "A person or organization legally responsible for the content of the published material"
+  },
+  "rsg": {
+    "code": "rsg",
+    "name": "Restager",
+    "note": "A person or organization, other than the original choreographer or director, responsible for restaging a choreographic or dramatic work and who contributes minimal new content"
+  },
+  "rsr": {
+    "code": "rsr",
+    "name": "Restorationist",
+    "note": "A person, family, or organization responsible for the set of technical, editorial, and intellectual procedures aimed at compensating for the degradation of an item by bringing it back to a state as close as possible to its original condition"
+  },
+  "rev": {
+    "code": "rev",
+    "name": "Reviewer",
+    "note": "A person or organization responsible for the review of a book, motion picture, performance, etc."
+  },
+  "rbr": {
+    "code": "rbr",
+    "name": "Rubricator",
+    "note": "A person or organization responsible for parts of a work, often headings or opening parts of a manuscript, that appear in a distinctive color, usually red"
+  },
+  "sce": {
+    "code": "sce",
+    "name": "Scenarist",
+    "note": "A person or organization who is the author of a motion picture screenplay, generally the person who wrote the scenarios for a motion picture during the silent era"
+  },
+  "sad": {
+    "code": "sad",
+    "name": "Scientific advisor",
+    "note": "A person or organization who brings scientific, pedagogical, or historical competence to the conception and realization on a work, particularly in the case of audio-visual items"
+  },
+  "aus": {
+    "code": "aus",
+    "name": "Screenwriter",
+    "note": "An author of a screenplay, script, or scene",
+    "uf": [
+      "Author of screenplay, etc."
+    ]
+  },
+  "scr": {
+    "code": "scr",
+    "name": "Scribe",
+    "note": "A person who is an amanuensis and for a writer of manuscripts proper. For a person who makes pen-facsimiles, use Facsimilist [fac]"
+  },
+  "scl": {
+    "code": "scl",
+    "name": "Sculptor",
+    "note": "An artist responsible for creating a three-dimensional work by modeling, carving, or similar technique"
+  },
+  "spy": {
+    "code": "spy",
+    "name": "Second party",
+    "note": "A person or organization who is identified as the party of the second part. In the case of transfer of right, this is the assignee, transferee, licensee, grantee, etc. Multiple parties can be named jointly as the second party"
+  },
+  "sec": {
+    "code": "sec",
+    "name": "Secretary",
+    "note": "A person or organization who is a recorder, redactor, or other person responsible for expressing the views of a organization"
+  },
+  "sll": {
+    "code": "sll",
+    "name": "Seller",
+    "note": "A former owner of an item who sold that item to another owner"
+  },
+  "std": {
+    "code": "std",
+    "name": "Set designer",
+    "note": "A person who translates the rough sketches of the art director into actual architectural structures for a theatrical presentation, entertainment, motion picture, etc. Set designers draw the detailed guides and specifications for building the set"
+  },
+  "stg": {
+    "code": "stg",
+    "name": "Setting",
+    "note": "An entity in which the activity or plot of a work takes place, e.g. a geographic place, a time period, a building, an event"
+  },
+  "sgn": {
+    "code": "sgn",
+    "name": "Signer",
+    "note": "A person whose signature appears without a presentation or other statement indicative of provenance. When there is a presentation statement, use Inscriber [ins]."
+  },
+  "sng": {
+    "code": "sng",
+    "name": "Singer",
+    "note": "A performer contributing to a resource by using his/her/their voice, with or without instrumental accompaniment, to produce music. A singer's performance may or may not include actual words",
+    "uf": [
+      "Vocalist"
+    ]
+  },
+  "sds": {
+    "code": "sds",
+    "name": "Sound designer",
+    "note": "A person who produces and reproduces the sound score (both live and recorded), the installation of microphones, the setting of sound levels, and the coordination of sources of sound for a production"
+  },
+  "spk": {
+    "code": "spk",
+    "name": "Speaker",
+    "note": "A performer contributing to a resource by speaking words, such as a lecture, speech, etc. "
+  },
+  "spn": {
+    "code": "spn",
+    "name": "Sponsor",
+    "note": "A person, family, or organization sponsoring some aspect of a resource, e.g., funding research, sponsoring an event",
+    "uf": [
+      "Sponsoring body"
+    ]
+  },
+  "sgd": {
+    "code": "sgd",
+    "name": "Stage director",
+    "note": "A person or organization contributing to a stage resource through the overall management and supervision of a performance"
+  },
+  "stm": {
+    "code": "stm",
+    "name": "Stage manager",
+    "note": "A person who is in charge of everything that occurs on a performance stage, and who acts as chief of all crews and assistant to a director during rehearsals"
+  },
+  "stn": {
+    "code": "stn",
+    "name": "Standards body",
+    "note": "An organization responsible for the development or enforcement of a standard"
+  },
+  "str": {
+    "code": "str",
+    "name": "Stereotyper",
+    "note": "A person or organization who creates a new plate for printing by molding or copying another printing surface"
+  },
+  "stl": {
+    "code": "stl",
+    "name": "Storyteller",
+    "note": "A performer contributing to a resource by relaying a creator's original story with dramatic or theatrical interpretation"
+  },
+  "sht": {
+    "code": "sht",
+    "name": "Supporting host",
+    "note": "A person or organization that supports (by allocating facilities, staff, or other resources) a project, program, meeting, event, data objects, material culture objects, or other entities capable of support",
+    "uf": [
+      "Host, supporting"
+    ]
+  },
+  "srv": {
+    "code": "srv",
+    "name": "Surveyor",
+    "note": "A person, family, or organization contributing to a cartographic resource by providing measurements or dimensional relationships for the geographic area represented"
+  },
+  "tch": {
+    "code": "tch",
+    "name": "Teacher",
+    "note": "A performer contributing to a resource by giving instruction or providing a demonstration",
+    "uf": [
+      "Instructor"
+    ]
+  },
+  "tcd": {
+    "code": "tcd",
+    "name": "Technical director",
+    "note": "A person who is ultimately in charge of scenery, props, lights and sound for a production"
+  },
+  "tld": {
+    "code": "tld",
+    "name": "Television director",
+    "note": "A director responsible for the general management and supervision of a television program"
+  },
+  "tlp": {
+    "code": "tlp",
+    "name": "Television producer",
+    "note": "A producer responsible for most of the business aspects of a television program"
+  },
+  "ths": {
+    "code": "ths",
+    "name": "Thesis advisor",
+    "note": "A person under whose supervision a degree candidate develops and presents a thesis, mémoire, or text of a dissertation",
+    "uf": [
+      "Promoter"
+    ]
+  },
+  "trc": {
+    "code": "trc",
+    "name": "Transcriber",
+    "note": "A person, family, or organization contributing to a resource by changing it from one system of notation to another. For a work transcribed for a different instrument or performing group, see Arranger [arr]. For makers of pen-facsimiles, use Facsimilist [fac]"
+  },
+  "trl": {
+    "code": "trl",
+    "name": "Translator",
+    "note": "A person or organization who renders a text from one language into another, or from an older form of a language into the modern form"
+  },
+  "tyd": {
+    "code": "tyd",
+    "name": "Type designer",
+    "note": "A person or organization who designs the type face used in a particular item",
+    "uf": [
+      "Designer of type"
+    ]
+  },
+  "tyg": {
+    "code": "tyg",
+    "name": "Typographer",
+    "note": "A person or organization primarily responsible for choice and arrangement of type used in an item. If the typographer is also responsible for other aspects of the graphic design of a book (e.g., Book designer [bkd]), codes for both functions may be needed"
+  },
+  "uvp": {
+    "code": "uvp",
+    "name": "University place",
+    "note": "A place where a university that is associated with a resource is located, for example, a university where an academic dissertation or thesis was presented"
+  },
+  "vdg": {
+    "code": "vdg",
+    "name": "Videographer",
+    "note": "A person in charge of a video production, e.g. the video recording of a stage production as opposed to a commercial motion picture. The videographer may be the camera operator or may supervise one or more camera operators. Do not confuse with cinematographer"
+  },
+  "vac": {
+    "code": "vac",
+    "name": "Voice actor",
+    "note": "An actor contributing to a resource by providing the voice for characters in radio and audio productions and for animated characters in moving image works, as well as by providing voice overs in radio and television commercials, dubbed resources, etc."
+  },
+  "wit": {
+    "code": "wit",
+    "name": "Witness",
+    "note": "Use for a person who verifies the truthfulness of an event or action.",
+    "uf": [
+      "Deponent",
+      "Eyewitness",
+      "Observer",
+      "Onlooker",
+      "Testifier"
+    ]
+  },
+  "wde": {
+    "code": "wde",
+    "name": "Wood engraver",
+    "note": "A person or organization who makes prints by cutting the image in relief on the end-grain of a wood block"
+  },
+  "wdc": {
+    "code": "wdc",
+    "name": "Woodcutter",
+    "note": "A person or organization who makes prints by cutting the image in relief on the plank side of a wood block"
+  },
+  "wam": {
+    "code": "wam",
+    "name": "Writer of accompanying material",
+    "note": "Writer of added commentary"
+  },
+  "wal": {
+    "code": "wal",
+    "name": "Writer of added lyrics",
+    "note": "A writer of words added to an expression of a musical work. For lyric writing in collaboration with a composer to form an original work, see lyricist"
+  },
+  "wat": {
+    "code": "wat",
+    "name": "Writer of added text",
+    "note": "A person, family, or organization contributing to a non-textual resource by providing text for the non-textual work (e.g., writing captions for photographs, descriptions of maps)."
+  },
+  "win": {
+    "code": "win",
+    "name": "Writer of introduction",
+    "note": "A person, family, or organization contributing to a resource by providing an introduction to the original work"
+  },
+  "wpr": {
+    "code": "wpr",
+    "name": "Writer of preface",
+    "note": "A person, family, or organization contributing to a resource by providing a preface to the original work"
+  },
+  "wst": {
+    "code": "wst",
+    "name": "Writer of supplementary textual content",
+    "note": "A person, family, or organization contributing to a resource by providing supplementary textual content (e.g., an introduction, a preface) to the original work"
+  }
+}

--- a/lib/marcrelators/index.js
+++ b/lib/marcrelators/index.js
@@ -1,0 +1,103 @@
+// MARC Code List for Relators
+// https://loc.gov/marc/relators/relaterm.html
+
+const {
+  stringEqualsCaseInsensitivePredicate,
+  stringComparatorBy,
+} = require("../functions/Functors");
+/*
+MarcRelatorTerm map entry definition (sorted by name)
+
+code: {
+  code: string
+  name: string
+  note: string
+  uf?: [ alias_name ]
+  use?: string
+}
+*/
+const data = require("./data.json");
+
+/**
+ * Get the MARC Relator term by its unique `code` field
+ * @param {string} code - a String representing the MARC relator term `code`
+ * @returns {MarcRelatorTerm | null} The relator term item. `null` if not found
+ */
+function findByCode(code) {
+  if (Object.prototype.hasOwnProperty.call(data, code)) {
+    return data[code];
+  }
+  return null; // not found
+}
+
+/**
+ * Get the MARC Relator term by its unique name or it aliases (used for)
+ * @param {string} name - a String representing the MARC relator term `name` or each `uf`
+ * @returns {MarcRelatorTerm | null} The relator term item. `null` if not found
+ */
+function findByName(name) {
+  const predicate = stringEqualsCaseInsensitivePredicate(name);
+  // iterate over object entries
+  for (const [_key, value] of Object.entries(data)) {
+    // over the field: `name`
+    if (predicate(value.name)) return value;
+    // over the field: `use-for` alias names
+    if (value.uf && value.uf.findIndex(predicate) !== -1) return value;
+  }
+  return null; // not found
+}
+
+function listAll() {
+  const list = [];
+  for (const value of Object.values(data)) {
+    list.push({ ...value }); // add shallow/weak clone
+    // convert `use-for` fields to `use` fields
+    if (value.uf) {
+      for (const use of value.uf) {
+        const item = { ...value }; // shallow/weak clone
+        item.name = use;
+        item.use = value.name;
+        delete item.uf; // `uf` and `use` fields are exclusive
+        list.push(item); // add
+      }
+    }
+  }
+  // sort by name
+  list.sort(stringComparatorBy("name", true, true));
+  return list;
+}
+
+(function init() {
+  console.log(
+    "MARC Relator Terms registry: " +
+      Object.keys(data).length +
+      " entries / " +
+      listAll().length +
+      " items."
+  );
+  /* Tests
+  console.log("listAllMarcRelators()", listAll());
+
+  console.log("findMarcRelatorByCode() = ", findByCode());
+  console.log("findMarcRelatorByCode(null) = ", findByCode(null));
+  console.log("findMarcRelatorByCode('trl') = ", findByCode("trl"));
+  console.log("findMarcRelatorByCode('wit') = ", findByCode("wit"));
+
+  console.log("findMarcRelatorByName() = ", findByName());
+  console.log("findMarcRelatorByName(null) = ", findByName(null));
+  console.log(
+    "findMarcRelatorByName('Translator') = ",
+    findByName("Translator")
+  );
+  console.log("findMarcRelatorByName('Witness') = ", findByName("Witness"));
+  console.log("findMarcRelatorByName('witness') = ", findByName("witness"));
+  console.log("findMarcRelatorByName('Observer') = ", findByName("Observer"));
+  console.log("findMarcRelatorByName('observer') = ", findByName("observer"));
+  */
+})();
+
+module.exports = {
+  findByCode,
+  findByName,
+  listAll,
+};


### PR DESCRIPTION
### What this PR do?

Add feature(s)

### Description

Recently we introduced the `ABBR.:` note in [markdown sources](https://github.com/EbookFoundation/free-programming-books/search?q=trl.%3A+is%3Apr&type=issues) to support relator abbreviations attached to each creator.

e.g. for creators of type translator: 
```markdown
`trl.:` an awesome translator
```
More relators terms: https://loc.gov/marc/relators/relaterm.html

This PR adds supports to them

### Context

I attach two files in a zip: [fpb-parser-data.zip](https://github.com/EbookFoundation/free-programming-books-parser/files/9623949/fpb-parser-data.zip). Compares them to test differences. It seems all right