### PR TITLE
[HOTFIX-11]: undefined `item` var -> `node`

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ function remarkTokenAST(node) {
       case "emphasis": // {type: 'emphasis', children: [...], position: {...}}
         return Strings.wrap("{{text}}", "_");
       case "heading": // {type: 'heading', depth: 1, children: [...], position: {...}}
-        return ["#".repeat(item.depth || 0), "{{text}}"].join("");
+        return ["#".repeat(node.depth || 0), "{{text}}"].join("");
       case "image": // {type: 'image', title: '...', url: '...', alt: '...', position: {...}}
         return "![{{text}}]({{url}})";
       case "inlineCode": // {type: 'inlineCode', value: '...', position: {...}}


### PR DESCRIPTION
Patch remarkTokenAST function to fix this error introduced in #11 

https://github.com/EbookFoundation/free-programming-books-parser/blob/c39d7a08662eef98a15d3d78411b9561483747a2/index.js#L134-145

Right variable name is `node`, not `item`